### PR TITLE
Update 3topLevel_inner.sh to skip storm import

### DIFF
--- a/upload/3topLevel_inner.sh
+++ b/upload/3topLevel_inner.sh
@@ -132,20 +132,31 @@ set echo on
 grant dba, connect , resource, unlimited tablespace, create session to storm identified by oracle;
 EOF
 cd ~/storm
-if test -f storm.zip
+if test "m$VM_DO_STORM" != "m"
 then
-    if test -f storm.dmp
+    if test -f storm.zip
     then
-        echo storm.zip already unzipped
-    else
-        echo unzipping storm.zip
-        unzip storm.zip  >> storm_vm_log 2>&1
+        if test -f storm.dmp
+        then
+            echo storm.zip already unzipped
+        else
+            echo unzipping storm.zip
+            unzip storm.zip  >> storm_vm_log 2>&1
+        fi
+        echo importing storm.dmp
+        imp storm/oracle@ORDS FILE=storm.dmp FULL=Y  >> storm_vm_log 2>&1
     fi
-    echo importing storm.dmp
-    imp storm/oracle@ORDS FILE=storm.dmp FULL=Y  >> storm_vm_log 2>&1
-fi 
+else
+    echo storm import skipped as VM_DO_STORM environmental variable not set
+fi
 echo End of Import">~oracle/bin/newpdbords
-chmod 755 ~oracle/bin/newpdbords' > /tmp/hrrest.sh
+echo "#!/bin/bash
+#storm import skipped in newpdbords unless this env variable is set
+export VM_DO_STORM=yes
+~oracle/bin/newpdbords
+"> ~oracle/bin/newpdbordsstorm
+chmod 755 ~oracle/bin/newpdbords
+chmod 755 ~oracle/bin/newpdbordsstorm' > /tmp/hrrest.sh
 chmod 755 /tmp/hrrest.sh
 su - oracle -c '/bin/bash -xc /tmp/hrrest.sh'
 rm /tmp/hrrest.sh


### PR DESCRIPTION
have newpdbords and newpdbordsstorm - the storm version imports the storm dump (used in spatial) - the storm dump load takes about 50% of the load time. Probably should also skip the import finished message - i.e it will now go import skipped then import finished, but I can live with that.